### PR TITLE
Fixing tooling error for events

### DIFF
--- a/model/vsc_parser.py
+++ b/model/vsc_parser.py
@@ -352,7 +352,7 @@ def ast_Events(parent, yamltree) -> list[Event]:
     for st in subtrees:
         node = Event(get_yaml_value(st, 'name'), parent)
         node.description = get_yaml_value(st, 'description')
-        node.in_arguments = ast_Arguments(node, st, 'in_arguments')
+        node.in_arguments = ast_Arguments(node, st, 'in')
         nodes.append(node)
 
     return nodes

--- a/templates/simple_overview.tpl
+++ b/templates/simple_overview.tpl
@@ -46,7 +46,7 @@ Header
          {% endfor %}
       {% endfor %}
       {% for x in n.properties %}
-         Event: {{ x.name }}
+         Property: {{ x.name }}
          -> {{ x.description }}
          -> Type: {{ x.type }}
          -> Datatype: {{ x.datatype }}


### PR DESCRIPTION
Tooling previously searched for "in_arguments" rather than "in".
Also fixed a printout in example template