### PR TITLE
Update parser to match language as defined in README.md

### DIFF
--- a/model/vsc_parser.py
+++ b/model/vsc_parser.py
@@ -382,7 +382,6 @@ def ast_Properties(parent, yamltree) -> list[Property]:
 def ast_Namespaces(parent, yamltree) -> list[Namespace]:
     subtrees = get_yaml_value(yamltree, 'namespaces')
     require_list(subtrees, 'namespaces')
-
     nodes = []
     for st in subtrees:
         node = Namespace(get_yaml_value(st, 'name'), parent)
@@ -409,14 +408,16 @@ def ast_Service(parent, yamltree) -> Service:
     # constructor requires it too.
     # For here, we use the service name as anytree node name.
     # (For other item types that are anonymous in the tree because they have no
-    # name spcified, then the item type is used as node name instead)
+    # name specified, then the item type is used as node name instead)
+    # Keep recursing into the child objects (but only the specific types
+    # that are expected in a valid file
+    # So for a service we expect namespaces as children
+
+    #FIXME this needs to be looked at?
     node = Service(get_yaml_value(yamltree, 'name'), parent)
 
     # After creating the node we simply assign other member attributes directly
 
-    # Keep recursing into the child objects (but only the specific types
-    # that are expected in a valid file
-    # So for a  service we expect datatypes and interfaces as children:
     node.description = get_yaml_value(yamltree, 'description')
 
     node.major_version = get_yaml_value(yamltree, 'major-version')

--- a/templates/Service-simple_doc.html
+++ b/templates/Service-simple_doc.html
@@ -4,7 +4,7 @@
    </head>
    <body>
       <h1>Service overview for {{item.name}}</h1>
-      {% for i in item.interfaces %}
+      {% for i in item.namespaces %}
          <h2>Methods</h2>
          {% for x in i.methods %}
             <p>

--- a/templates/sds-bamm-macros.tpl
+++ b/templates/sds-bamm-macros.tpl
@@ -86,8 +86,6 @@
      {% else -%}
      {% if member.datatype and not member.datatype.endswith("_t") %}
      bamm:dataType {{ _render_datatype(member.datatype) }} .
-     {% elif member.type and not member.type.endswith("_t") %}
-     bamm:dataType {{ _render_datatype(member.type) }} .
      {% else %}
      bamm:dataType {{ _render_characteristic_type(member) }} .
      {% endif %}
@@ -113,7 +111,7 @@ a bamm-c:RangeConstraint ;
 {% endmacro -%}
 
 {% macro _render_characteristic_definition(member) %}
-{% set type = member.type if member.type else member.datatype -%}
+{% set type = member.datatype -%}
 {% if member.datatype and (member.min or member.max) %}
     {{- "bamm-c:Trait" -}}
 {% elif type.endswith("[]") %}
@@ -176,8 +174,6 @@ a bamm-c:RangeConstraint ;
 {{ member.name }}
 {%- elif member.datatype and member.datatype.endswith("_t") -%}
 Characteristic{{ snake_to_camel(member.datatype.capitalize()) }}
-{%- elif member.type and member.type.endswith("_t") -%}
-Characteristic{{ snake_to_camel(member.type.capitalize()) }}
 {%- else -%}
 Characteristic{{ snake_to_camel(member.name.capitalize()) }}
 {%- endif -%}
@@ -185,9 +181,5 @@ Characteristic{{ snake_to_camel(member.name.capitalize()) }}
 
 {# Render characteristic datatype #}
 {%- macro _render_characteristic_type(member) -%}
-{%- if member.datatype -%}
 :{{ snake_to_camel(member.datatype.capitalize()) }}
-{%- else -%}
-:{{ snake_to_camel(member.type.capitalize()) }}
-{%- endif -%}
 {%- endmacro -%}

--- a/templates/simple_overview.tpl
+++ b/templates/simple_overview.tpl
@@ -11,7 +11,7 @@ Header
          Struct: {{ x.name }}
          -> {{ x.description }}
          {% for x in x.members %}
-            member: {{ x.name }} (of type {{x.type}}) 
+            member: {{ x.name }} (of type {{x.datatype}}) 
          {% endfor %}
       {% endfor %}
       {% for x in n.typedefs %}
@@ -32,24 +32,23 @@ Header
          Method: {{ x.name }}
          -> {{ x.description }}
          {% for x in x.in_arguments %}
-            in: {{ x.name }} (of type {{x.type}}) 
+            in: {{ x.name }} (of type {{x.datatype}}) 
          {% endfor %}
          {% for x in x.out_arguments %}
-            out: {{ x.name }} (of type {{x.type}}) 
+            out: {{ x.name }} (of type {{x.datatype}}) 
          {% endfor %}
       {% endfor %}
       {% for x in n.events %}
          Event: {{ x.name }}
          -> {{ x.description }}
          {% for x in x.in_arguments %}
-            in: {{ x.name }} (of type {{x.type}}) 
+            in: {{ x.name }} (of type {{x.datatype}}) 
          {% endfor %}
       {% endfor %}
       {% for x in n.properties %}
          Property: {{ x.name }}
          -> {{ x.description }}
-         -> Type: {{ x.type }}
-         -> Datatype: {{ x.datatype }}
+         -> Type: {{ x.datatype }}
       {% endfor %}
    {% endfor %}
 {% endfor %}

--- a/tests/input
+++ b/tests/input
@@ -1,4 +1,6 @@
 name: named_service
+major-version: 3
+minor-version: 0
 description: This is it.
 namespaces:
     - name: if


### PR DESCRIPTION
First change to update parser to match current description of the VSC
syntax (as stated in README.md of vehicle_service_catalog, _currently_)

(There could still be some bugs in either this code, and/or the description in the README, but this brings the tools at least roughly up to date with what is described there).
