### PR TITLE
Fix template regressions

### DIFF
--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -30,7 +30,25 @@ jobs:
         run: |
           pytest -v
 
+      - name: Prepare for test using latest VSC
+        run: |
+          git clone https://github.com/COVESA/vehicle_service_catalog/
+
       - name: Run example tool on latest VSC
         run: |
-          git clone https://github.com/COVESA/vehicle_service_catalog/ -b input_output
           vscgen vehicle_service_catalog/comfort-service.yml simple_overview.tpl
+
+      - name: Run DTDL template on latest VSC
+        run: |
+          vscgen vehicle_service_catalog/comfort-service.yml dtdl.tpl > dtdl.out
+
+      - name: Run Protobuf template on latest VSC and verify output is correct Proto
+        run: |
+          sudo apt install -y protobuf-compiler
+          vscgen vehicle_service_catalog/comfort-service.yml protobuf.tpl > vsc.proto
+          mkdir tmp
+          protoc --cpp_out=tmp vsc.proto
+
+      - name: Run BAMM template on latest VSC
+        run: |
+          vscgen vehicle_service_catalog/comfort-service.yml sds-bamm-aspect-model.tpl > bamm.out

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "fee3a39c7f056d348fa433a215cc0d67a2cd9dc655b8b0a7756343fad72ed4d9"
+            "sha256": "21c8b5d6b7c58a3cca7d0dec6085cebd884ddb8a6054ae9c8e8488cf6e45a7db"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,11 +26,19 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4",
-                "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"
+                "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6",
+                "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==21.4.0"
+            "markers": "python_version >= '3.5'",
+            "version": "==22.1.0"
+        },
+        "dacite": {
+            "hashes": [
+                "sha256:4331535f7aabb505c732fa4c3c094313fc0a1d5ea19907bf4726a7819a68b93f",
+                "sha256:d48125ed0a0352d3de9f493bf980038088f45f3f9d7498f090b50a847daaa6df"
+            ],
+            "index": "pypi",
+            "version": "==1.6.0"
         },
         "iniconfig": {
             "hashes": [
@@ -127,14 +135,15 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:13d0e3ccfc2b6e26be000cb6568c832ba67ba32e719443bfe725814d3c42433c",
-                "sha256:a06a0425453864a270bc45e71f783330a7428defb4230fb5e6a731fde06ecd45"
+                "sha256:1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7",
+                "sha256:4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39"
             ],
             "index": "pypi",
-            "version": "==7.1.2"
+            "version": "==7.1.3"
         },
         "pyyaml": {
             "hashes": [
+                "sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf",
                 "sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293",
                 "sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b",
                 "sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57",
@@ -146,26 +155,32 @@
                 "sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287",
                 "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513",
                 "sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0",
+                "sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782",
                 "sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0",
                 "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92",
                 "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f",
                 "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2",
                 "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc",
+                "sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1",
                 "sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c",
                 "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86",
                 "sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4",
                 "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c",
                 "sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34",
                 "sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b",
+                "sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d",
                 "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c",
                 "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb",
+                "sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7",
                 "sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737",
                 "sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3",
                 "sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d",
+                "sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358",
                 "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53",
                 "sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78",
                 "sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803",
                 "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a",
+                "sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f",
                 "sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174",
                 "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"
             ],

--- a/vsc/templates/dtdl.md
+++ b/vsc/templates/dtdl.md
@@ -102,7 +102,7 @@ The tool can be used like below:
 cd vsc-tools
 # make sure that vsc has been cloned
 git clone https://github.com/COVESA/vehicle_service_catalog/
-python model/vsc_generator.py vehicle_service_catalog/comfort-service.yml dtdl.tpl > dtdl_generated.json
+vscgen vehicle_service_catalog/comfort-service.yml dtdl.tpl > dtdl_generated.json
 ```
 
 ### Validating generated DTDL files

--- a/vsc/templates/protobuf.md
+++ b/vsc/templates/protobuf.md
@@ -48,7 +48,7 @@ cd vsc-tools
 # make sure that vsc has been cloned
 git clone https://github.com/COVESA/vehicle_service_catalog/
 # Run the generator
-python model/vsc_generator.py vehicle_service_catalog/comfort-service.yml protobuf.tpl > vsc.proto
+vscgen vehicle_service_catalog/comfort-service.yml protobuf.tpl > vsc.proto
 ```
 
 ### Validating generated Protobuf files

--- a/vsc/templates/protobuf.tpl
+++ b/vsc/templates/protobuf.tpl
@@ -10,17 +10,17 @@ syntax = "proto3";
 {# Add all type conversion  #}
 {% set x=typedefs.__setitem__("int16", "int32") %}
 {% set x=typedefs.__setitem__("uint8", "uint32") %}
+{% set x=typedefs.__setitem__("uint16", "uint32") %}
 {% set x=typedefs.__setitem__("boolean", "bool") %}
 
-{% for s in item.children %}
-package swdv.{{s.name}};
+package swdv.{{item.name}};
 
 // Generic result message
 message operation_result {
   bool result = 1;
 }
 
-   {% for n in s.namespaces %}
+   {% for n in item.namespaces %}
 // VSC Namespace {{n.name}}
 {# Typedefs and enum must be handled before structs, to convert types right #}
 {# Limitation: for now we ignore namespaces #}
@@ -62,7 +62,7 @@ message {{x.name}} {
       {% for x in n.methods %}
 // VSC Method {{x.name}}
 message {{ x.name }}_request {
-         {% for x in x.in %}
+         {% for x in x.input %}
            {% if x.datatype in  typedefs %}
              {% set type = typedefs[x.datatype] %}
            {% else %}
@@ -73,7 +73,7 @@ message {{ x.name }}_request {
 }
 
 message {{ x.name }}_response {
-         {% for x in x.out %}
+         {% for x in x.output %}
            {% if x.datatype in  typedefs %}
              {% set type = typedefs[x.datatype] %}
            {% else %}
@@ -93,7 +93,7 @@ service {{ x.name }}_service {
 // VSC Event {{x.name}}
       {# Limitation: for now just creating a message #}
 message {{ x.name }} {
-         {% for x in x.in %}
+         {% for x in x.input %}
            {% if x.datatype in  typedefs %}
              {% set type = typedefs[x.datatype] %}
            {% else %}
@@ -128,5 +128,4 @@ service {{ x.name }} {
       {% endfor %}
    {% endfor %}
 
-{% endfor %}
 

--- a/vsc/templates/sds-bamm-aspect-model.md
+++ b/vsc/templates/sds-bamm-aspect-model.md
@@ -39,7 +39,7 @@ The tool can be used like below:
 cd vsc-tools
 # make sure that vsc has been cloned
 git clone https://github.com/COVESA/vehicle_service_catalog/
-python model/vsc_generator.py vehicle_service_catalog/comfort-service.yml sds-bamm-aspect-model.tpl > comfort/2.0.1/seat.ttl
+vscgen vehicle_service_catalog/comfort-service.yml sds-bamm-aspect-model.tpl > comfort/2.0.1/seat.ttl
 ```
 
 ### Mapping of the different concepts

--- a/vsc/templates/sds-bamm-aspect-model.tpl
+++ b/vsc/templates/sds-bamm-aspect-model.tpl
@@ -1,7 +1,7 @@
 {% import 'sds-bamm-macros.tpl' as bamm %}
 
-{% set aspectModelURN = item.children[0].name %}
-{% set aspectModelVersion = item.children[0].major_version ~ '.' ~ item.children[0].minor_version ~ '.0' %}
+{% set aspectModelURN = item.name %}
+{% set aspectModelVersion = item.major_version ~ '.' ~ item.minor_version ~ '.0' %}
 
 @prefix: <urn:bamm:{{ aspectModelURN }}:{{ aspectModelVersion }}#>.
 @prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:1.0.0#> .
@@ -10,11 +10,10 @@
 @prefix unit: <urn:bamm:io.openmanufacturing:unit:1.0.0#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-{%for s in item.children %}
 
     {# --- Aspect --- #}
 
-    {% for n in s.namespaces -%}
+    {% for n in item.namespaces -%}
     {{ bamm.render_aspect(n) }}
 
     {# --- Operations --- #}
@@ -44,16 +43,16 @@
     {% endfor %}
 
     {%- for event in n.events -%}
-    {%- for in_arg in event.in -%}
+    {%- for in_arg in event.input -%}
     {{ bamm.render_property(in_arg) }}
     {% endfor %}
     {% endfor %}
 
     {%- for method in n.methods -%}
-    {%- for inProp in method.in -%}
+    {%- for inProp in method.input -%}
     {{ bamm.render_property(inProp) }}
     {% endfor %}
-    {%- for outProp in method.out -%}
+    {%- for outProp in method.output -%}
     {{ bamm.render_property(outProp) }}
     {% endfor %}
     {% endfor %}
@@ -75,19 +74,18 @@
     {% endfor %}
 
     {%- for event in n.events -%}
-    {%- for in_arg in event.in -%}
+    {%- for in_arg in event.input -%}
     {{ bamm.render_characteristic(in_arg) }}
     {% endfor %}
     {% endfor %}
 
     {%- for method in n.methods -%}
-    {%- for inProp in method.in -%}
+    {%- for inProp in method.input -%}
     {{ bamm.render_characteristic(inProp) }}
     {% endfor %}
-    {%- for outProp in method.out -%}
+    {%- for outProp in method.output -%}
     {{ bamm.render_characteristic(outProp) }}
     {% endfor %}
     {% endfor %}
 
     {% endfor %}
-{% endfor %}

--- a/vsc/templates/sds-bamm-macros.tpl
+++ b/vsc/templates/sds-bamm-macros.tpl
@@ -13,11 +13,17 @@
     {% endfor %}
 {% endmacro %}
 
+
+{# Macro to strip newline in description #}
+{% macro render_description(x) -%}
+bamm:description "{{ x.description.strip().replace("\n", " ") }}"@en ;
+{%- endmacro %}
+
 {# Render an Aspect definition based on a VSC Namespace #}
 {% macro render_aspect(element) %}
-:{{ element.name.capitalize() }} a bamm:Aspect ;
+:{{ element.name.capitalize() }} a bamm:Aspect ;-
     bamm:name "{{ element.name.capitalize() }}" ;
-    bamm:description "{{ element.description }}"@en ;
+    {{ render_description(element) }}
     bamm:properties () ;
     bamm:operations ({{ element_names(element.methods) }}) ;
     bamm:events ({{ element_names(element.events) }}) .
@@ -29,10 +35,10 @@
 {%- set _ = bammElementDictonary.update({method.name: method}) -%}
 :{{ snake_to_camel(method.name.capitalize()) }} a bamm:Operation ;
     bamm:name "{{ snake_to_camel(method.name.capitalize()) }}" ;
-    bamm:description "{{ method.description }}"@en ;
-    bamm:input ({{ element_names(method.in, true) }}) {{ ";" if method.out|length > 0 else "." }} 
-    {% if method.out|length > 0 %}
-    bamm:output {{ element_names([method.out[0]], true) }} .
+    {{ render_description(method) }}
+    bamm:input ({{ element_names(method.input, true) }}) {{ ";" if method.output|length > 0 else "." }} 
+    {% if method.output|length > 0 %}
+    bamm:output {{ element_names([method.output[0]], true) }} .
     {% endif %}
 {% endif %}
 {% endmacro %}
@@ -43,7 +49,7 @@
 {%- set _ = bammElementDictonary.update({member.name: member}) -%}
 :{{ snake_to_camel(member.name) }} a bamm:Property ;
     bamm:name "{{ snake_to_camel(member.name) }}" ;
-    bamm:description "{{ member.description }}"@en ;
+    {{ render_description(member) }}
     bamm:characteristic :{{ _render_characteristic_name(member) }} .
 {% endif -%}
 {% endmacro %}
@@ -54,8 +60,8 @@
 {%- set _ = bammElementDictonary.update({event.name: event}) -%}
 :{{ snake_to_camel(event.name.capitalize()) }} a bamm:Event ;
     bamm:name "{{ snake_to_camel(event.name.capitalize()) }}" ;
-    bamm:description "{{ event.description }}"@en ;
-    bamm:parameters ({{ element_names(event.in, true) }}) .
+    {{ render_description(event) }}
+    bamm:parameters ({{ element_names(event.input, true) }}) .
 {% endif %}
 {% endmacro %}
 
@@ -65,7 +71,7 @@
 {%- set _ = bammElementDictonary.update({struct.name: struct}) -%}
 :{{ snake_to_camel(struct.name.capitalize()) }} a bamm:Entity ;
     bamm:name "{{ snake_to_camel(struct.name.capitalize()) }}" ;
-    bamm:description "{{ struct.description }}"@en ;
+    {{ render_description(struct) }}
     bamm:properties ({{ element_names(struct.members, true) }}) .
 {% endif %}
 {% endmacro %}
@@ -77,7 +83,7 @@
 {%- set _ = bammElementDictonary.update({characteristic_name: member}) -%}
 :{{ characteristic_name }} a {{ _render_characteristic_definition(member) }} ;
      bamm:name "{{ characteristic_name }}" ;
-     bamm:description "{{ member.description }}"@en ;
+     {{ render_description(member) }}
      {% if (member.min is defined) and (member.min or member.max) %}
      bamm-c:baseCharacteristic :{{ characteristic_name }}Base ;
      bamm-c:constraint [


### PR DESCRIPTION
Fixes the following problems:

- Top item is now a "service" (i.e. one level in tree removed)
- In/Out renamed to Input/Output
- Line-break handling for descriptions. The seat example service uses it quite a lot, the target languages here does not support it, at least not without escapes. For now just removing line breaks.

Also extending CI checks for templates. This practically means that any changes introduced to tools or to the example seat service causing regressions will be detected. 

Signed-off-by: Erik Jaegervall <erik.jaegervall@se.bosch.com>